### PR TITLE
Moved scope exit down as this fails to compile on windows.

### DIFF
--- a/src/sdc/terminal.d
+++ b/src/sdc/terminal.d
@@ -140,7 +140,10 @@ void writeColouredText(File pipe, ConsoleColour colour, scope void delegate() dg
 			
 			GetConsoleScreenBufferInfo(handle, &termInfo);		
 			SetConsoleTextAttribute(handle, colour);
-			SetConsoleTextAttribute(handle, termInfo.wAttributes);
+			
+			scope (exit) {
+				SetConsoleTextAttribute(handle, termInfo.wAttributes);
+			}			
 		} else {
 			static char[5] ansiSequence = [0x1B, '[', '3', '0', 'm'];
 			ansiSequence[3] = cast(char)(colour + '0');

--- a/src/sdc/terminal.d
+++ b/src/sdc/terminal.d
@@ -132,10 +132,6 @@ void writeColouredText(File pipe, ConsoleColour colour, scope void delegate() dg
 			HANDLE handle;
 			CONSOLE_SCREEN_BUFFER_INFO termInfo;
 			
-			scope (exit) {
-				SetConsoleTextAttribute(handle, termInfo.wAttributes);
-			}
-			
 			if(pipe == stderr) {
 				handle = GetStdHandle(STD_ERROR_HANDLE);
 			} else {
@@ -144,6 +140,7 @@ void writeColouredText(File pipe, ConsoleColour colour, scope void delegate() dg
 			
 			GetConsoleScreenBufferInfo(handle, &termInfo);		
 			SetConsoleTextAttribute(handle, colour);
+			SetConsoleTextAttribute(handle, termInfo.wAttributes);
 		} else {
 			static char[5] ansiSequence = [0x1B, '[', '3', '0', 'm'];
 			ansiSequence[3] = cast(char)(colour + '0');

--- a/src/sdc/terminal.d
+++ b/src/sdc/terminal.d
@@ -128,13 +128,6 @@ version(Windows) {
 void writeColouredText(File pipe, ConsoleColour colour, scope void delegate() dg) {
 	bool coloursEnabled = true;  // XXX: Fix me!
 	if(coloursEnabled) {
-		scope (exit) {
-			version(Windows) {
-				SetConsoleTextAttribute(handle, termInfo.wAttributes);
-			} else {
-				pipe.write("\x1b[0m");
-			}
-		}
 		version(Windows) {
 			HANDLE handle;
 			
@@ -152,6 +145,13 @@ void writeColouredText(File pipe, ConsoleColour colour, scope void delegate() dg
 			static char[5] ansiSequence = [0x1B, '[', '3', '0', 'm'];
 			ansiSequence[3] = cast(char)(colour + '0');
 			pipe.write(ansiSequence);
+		}
+		scope (exit) {
+			version(Windows) {
+				SetConsoleTextAttribute(handle, termInfo.wAttributes);
+			} else {
+				pipe.write("\x1b[0m");
+			}
 		}
 		
 		dg();


### PR DESCRIPTION
Moved scope exit down as this fails to compile on windows.