### PR TITLE
Add `make test` target

### DIFF
--- a/makefile
+++ b/makefile
@@ -50,4 +50,7 @@ doc:
 
 print-%: ; @echo $*=$($*)
 
+test: $(SDC) $(LIBSDRT)
+	cd ./tests; ./runner.d
+
 .PHONY: clean run debug doc

--- a/tests/runner.d
+++ b/tests/runner.d
@@ -1,3 +1,4 @@
+#!/bin/env rdmd
 /**
  * Copyright 2010-2011 Bernard Helyer
  * Copyright 2011 Jakob Ovrum


### PR DESCRIPTION
Ensures all mandatory dependencies are built and calls test runner