### PR TITLE
Fixing make test by adding a compilation step of the runner script.

### DIFF
--- a/makefile
+++ b/makefile
@@ -51,6 +51,6 @@ doc:
 print-%: ; @echo $*=$($*)
 
 test: $(SDC) $(LIBSDRT)
-	cd ./tests; ./runner.d
+	cd ./tests;$(DMD) runner.d; ./runner; 
 
 .PHONY: clean run debug doc

--- a/makefile
+++ b/makefile
@@ -51,6 +51,6 @@ doc:
 print-%: ; @echo $*=$($*)
 
 test: $(SDC) $(LIBSDRT)
-	cd ./tests;$(DMD) runner.d; ./runner; 
+	cd ./tests; ./runner.d
 
-.PHONY: clean run debug doc
+.PHONY: clean run debug doc test

--- a/tests/runner.d
+++ b/tests/runner.d
@@ -1,4 +1,4 @@
-#!/bin/env rdmd
+#!/usr/bin/env rdmd
 /**
  * Copyright 2010-2011 Bernard Helyer
  * Copyright 2011 Jakob Ovrum


### PR DESCRIPTION
Hi,

I added a compilation step for the runner script before running it in the make test to fix. This worked, but is there a better way to get it done. 

Regards,
George