### PR TITLE
Fix issue #78 partially 

### DIFF
--- a/libd/src/d/ir/dscope.d
+++ b/libd/src/d/ir/dscope.d
@@ -266,6 +266,10 @@ class CapturingScope(S) : S  if(is(S : SymbolScope)){
 		auto s = parent.search(name);
 
 		import d.common.qualifier;
+		if (symbol.storage == Storage.Static && s.storage != Storage.Static) {
+			return null;
+		}
+
 		if (s !is null && typeid(s) is typeid(Variable) && !s.storage.isNonLocal) {
 			capture[() @trusted {
 				// Fast cast can be trusted in this case, we already did the check.


### PR DESCRIPTION
return null
if a nonStatic Symbol is fetched from a static closure.
For this to really fix #78 a static class/struct/function must be get the Storage.Static in the corresponding analyzer